### PR TITLE
feat: search executions by all filters at same time

### DIFF
--- a/card-templates/view-executions.json
+++ b/card-templates/view-executions.json
@@ -45,42 +45,36 @@
                 "value": "ALL"
               },
               {
-                "title": "User",
-                "value": "USER"
-              },
-              {
-                "title": "Date",
-                "value": "DATE"
-              },
-              {
-                "title": "Status",
-                "value": "STATUS"
-              },
-              {
-                "title": "Execution",
+                "title": "By execution name",
                 "value": "EXECUTION"
+              },
+              {
+                "title": "By filters",
+                "value": "FILTER"
               }
             ]
           },
           {
-            "showWhen": "data.executions.params.view === 'USER'",
+            "showWhen": "data.executions.params.view === 'FILTER'",
             "id": "userId",
             "type": "Input.Text",
             "title": "User ID",
             "spacing": "medium"
           },
           {
-            "showWhen": "data.executions.params.view === 'DATE'",
+            "showWhen": "data.executions.params.view === 'FILTER'",
             "id": "date",
             "type": "Input.Date",
+            "clearable": true,
             "title": "Date",
             "spacing": "medium",
             "max": "$TODAY"
           },
           {
-            "showWhen": "data.executions.params.view === 'STATUS'",
+            "showWhen": "data.executions.params.view === 'FILTER'",
             "id": "status",
             "type": "Input.ChoiceSet",
+            "clearable": true,
             "title": "Status",
             "value": "RUNNING",
             "choices": [

--- a/functions/get-executions.js
+++ b/functions/get-executions.js
@@ -46,7 +46,7 @@ module.exports = function () {
       if (userId) whereParts.push(`execution_options::jsonb->>'userId' = '${userId}'`)
       if (status) whereParts.push(`status = '${status}'`)
 
-      const where = `${whereParts.length > 0 ? 'WHERE ' : '' }${whereParts.join(' AND ')}`
+      const where = `${whereParts.length > 0 ? 'WHERE ' : ''}${whereParts.join(' AND ')}`
 
       query = `${select} ${where} ${end};`
       totalHitsQuery = `${selectCount} ${where};`

--- a/functions/user-executions-init-data.js
+++ b/functions/user-executions-init-data.js
@@ -13,9 +13,9 @@ module.exports = function () {
       params: {
         date: null,
         executionName: null,
-        status: 'RUNNING',
+        status: null,
         userId: event.userId,
-        view: 'USER'
+        view: 'FILTER'
       },
       results: [],
       summary: {
@@ -24,7 +24,7 @@ module.exports = function () {
     }
 
     const { results, totalHits } = await getExecutions(env, {
-      view: 'USER',
+      view: 'FILTER',
       userId: event.userId,
       offset: 0,
       limit: 10


### PR DESCRIPTION
Previously you could only search for executions individually by user id/status/date but now you can search with all the filters together.